### PR TITLE
Refactor web_search tool handling

### DIFF
--- a/MimicContentView.swift
+++ b/MimicContentView.swift
@@ -144,7 +144,6 @@ struct MimicContentView: View {
         runner.generateWithToolsStreaming(
             prefs: prefs,
             history: history,
-            forceSearchIfUserAsked: text.lowercased().contains("search") || text.lowercased().contains("find "),
             onEvent: { _ in },
             completion: { result in
                 switch result {

--- a/Models.swift
+++ b/Models.swift
@@ -99,9 +99,12 @@ struct WSPayload: Codable {
 struct ToolCall: Codable {
     struct Args: Codable {
         var query: String
-        var k: Int?
-        var summarize: Bool?
-        var preview_chars: Int?
+        var topK: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case query
+            case topK = "top_k"
+        }
     }
     var tool: String
     var args: Args

--- a/PromptTemplate.swift
+++ b/PromptTemplate.swift
@@ -50,8 +50,9 @@ struct PromptTemplate {
         }
 
         sysLines.append("After </think>, deliver a refined response in natural prose — no headers like 'Final Answer' or 'Response:'. If summarizing, integrate it gracefully into your last sentence.")
-        sysLines.append("Tools available: web_search(query: string, k?: int=5, summarize?: bool=true, preview_chars?: int=2000).")
-        sysLines.append(#"You are not forced to do a web search every time the user interacts with you. When current information is needed or the user asks to search, output a single line: <tool_call>{"tool":"web_search","args":{"query":"...","k":5,"summarize":true,"preview_chars":2000}}</tool_call>"#)
+        sysLines.append("Tools available: web_search(query: string, top_k?: int=5).")
+        sysLines.append(#"You are not forced to do a web search every time the user interacts with you. When current information is needed or the user asks to search, output a single line: <tool_call>{"tool":"web_search","args":{"query":"...","top_k":5}}</tool_call>"#)
+        sysLines.append("Only include \"query\" and optional \"top_k\" in the args object—no other keys are allowed.")
         sysLines.append(#"Wait for <tool_result name=\"web_search\">{...}</tool_result> before continuing, then cite only those URLs. If no tool_result is available, do not invent or cite URLs, do not claim to have visited URLs, and do not add a 'Sources:' section."#)
 
         if !toolSpec.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {

--- a/Sanitizer.swift
+++ b/Sanitizer.swift
@@ -22,6 +22,7 @@ enum Sanitizer {
             try! NSRegularExpression(pattern: "(?i)^When current information is needed.*$", options: [.anchorsMatchLines]),
             try! NSRegularExpression(pattern: "(?i)^Wait for <tool_result.*$", options: [.anchorsMatchLines]),
             try! NSRegularExpression(pattern: "(?i)^Use web_search for anything.*$", options: [.anchorsMatchLines]),
+            try! NSRegularExpression(pattern: "(?i)^Only include \"query\" and optional \"top_k\".*$", options: [.anchorsMatchLines]),
             try! NSRegularExpression(pattern: "(?i)^\\[\\[policy.*\\]\\]$", options: [.anchorsMatchLines])
         ]
     }()

--- a/WebSearchService.swift
+++ b/WebSearchService.swift
@@ -25,9 +25,7 @@ final class WebSearchService {
 
     func web_search(
         query: String,
-        k: Int = 5,
-        summarize: Bool = true,
-        previewChars: Int = 2000,
+        topK: Int = 5,
         progress: @escaping (SearchProgress) -> Void,
         completion: @escaping (Result<WSPayload, Error>) -> Void
     ) {
@@ -36,7 +34,9 @@ final class WebSearchService {
             do {
                 progress(.status("Planning query…"))
                 // Clamp inputs to keep downstream prompts within budget
-                let cappedK = max(1, min(5, k))
+                let cappedK = max(1, min(5, topK))
+                let previewChars = 2000
+                let summarize = true
                 let cappedPreview = max(200, min(1500, previewChars))
                 // Engine cascade
                 var candidates: [WSEngineResult] = []


### PR DESCRIPTION
## Summary
- collapse ToolCall arguments to the minimal query/top_k schema and update prompts and sanitization to match
- rework LLMRunner tool parsing to emit corrective tool_result messages for malformed JSON and only flag search usage on success
- update WebSearchService to accept a topK parameter and adjust callers, including MimicContentView

## Testing
- `swift - <<'SWIFT' ...` (verifies canonical tool call encoding/decoding and malformed payload output)


------
https://chatgpt.com/codex/tasks/task_e_68e5187dbb788323bdfb779ff869a222