### PR TITLE
Improve web search diagnostics and failure handling

### DIFF
--- a/Models.swift
+++ b/Models.swift
@@ -93,6 +93,7 @@ struct WSPayload: Codable {
     var queryHints: [String]
     var summarized: Bool
     var debug: [String: String]?
+    var error: String?
 }
 
 // Tool call decode


### PR DESCRIPTION
## Summary
- add detailed stage-aware debugging and error wrapping to `WebSearchService`
- extend the web search payload model to include optional error metadata
- surface richer search failure messaging in `LLMRunner` and emit structured failure payloads

## Testing
- not run (not supported in container)


------
https://chatgpt.com/codex/tasks/task_e_68e57f0ffc7c8323bc7714def6049e68